### PR TITLE
[PCE-4717] add missing check for payByLinks array

### DIFF
--- a/Payu/Gateways/WC_Gateway_PayuInstallments.php
+++ b/Payu/Gateways/WC_Gateway_PayuInstallments.php
@@ -19,7 +19,7 @@ class WC_Gateway_PayuInstallments extends WC_Payu_Gateways implements WC_PayuCre
 	public function get_available_paymethods() {
 		$response   = $this->payu_get_paymethods();
 		$payMethods = [];
-		if ( isset( $response ) && $response->getStatus() === 'SUCCESS' ) {
+		if ( isset( $response ) && $response->getStatus() === 'SUCCESS' && $response->getResponse()->payByLinks ) {
 			$pay_by_links = $response->getResponse()->payByLinks;
 			$payMethods   = array_map( fn( $paymethod ) => $paymethod->value, $pay_by_links );
 		}


### PR DESCRIPTION
Changes:
- fiexed bug where, if there weren't any paymethods configured on POS, a  critical error was thrown
![32760338_blad](https://github.com/user-attachments/assets/3d7930cd-10cb-4760-a93f-cd1cf8e03154)
