### PR TITLE
Limit widget script load

### DIFF
--- a/Payu/Blocks/CreditWidget/CreditWidgetBlock.php
+++ b/Payu/Blocks/CreditWidget/CreditWidgetBlock.php
@@ -35,7 +35,6 @@ abstract class CreditWidgetBlock implements IntegrationInterface {
 			$version,
 			true
 		);
-		wp_enqueue_script( 'payu-installments-widget', 'https://static.payu.com/res/v2/widget-mini-installments.js' );
 	}
 
 	public function get_script_handles(): array {
@@ -59,13 +58,18 @@ abstract class CreditWidgetBlock implements IntegrationInterface {
 	}
 
 	private function widget_on_page_enabled(): bool {
-		if ( ! is_any_credit_paymethod_available() ) {
-			return false;
-		}
+        if ( ! $this->is_widget_enabled_in_settings() || ! is_any_credit_paymethod_available() ) {
+            return false;
+        }
+        wp_enqueue_script( 'payu-installments-widget', 'https://static.payu.com/res/v2/widget-mini-installments.js' );
 
-		$payu_settings = get_option( 'payu_settings_option_name', [] );
-		$setting_name  = 'credit_widget_on_' . $this->page . '_page';
-
-		return isset( $payu_settings[ $setting_name ] ) && $payu_settings[ $setting_name ] === 'yes';
+        return true;
 	}
+
+    private function is_widget_enabled_in_settings(): bool {
+        $payu_settings = get_option( 'payu_settings_option_name', [] );
+        $setting_name  = 'credit_widget_on_' . $this->page . '_page';
+
+        return isset( $payu_settings[ $setting_name ] ) && $payu_settings[ $setting_name ] === 'yes';
+    }
 }

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ From user point of view, repayment is possible:
 ## Credit widget
 Plugin provides seamless integration of [credit widget][ext14]. It's responsible for presenting minimal installment amount for a given product.
 Additionally, after clicking on the widget, information on available repayment plans is presented, as well as a list of deferred payment methods (“buy now, pay later”).
-Functionality is enabled by default. It can be deactivated in administration panel (WooCommerce->Settings->Payments->PayU - installments).
+Functionality is enabled by default. It can be deactivated in administration panel (WooCommerce->PayU settings).
 Integration points of a widget have been described in a table below.
 
 | Checkbox Installments widget | Description | Presentation |

--- a/woocommerce-gateway-payu.php
+++ b/woocommerce-gateway-payu.php
@@ -405,7 +405,7 @@ function installments_mini_product() {
     $lang = get_site_language();
     $currency = get_woocommerce_currency();
 
-	wp_enqueue_script( 'payu-installments-widget', 'https://static.payu.com/res/v2/widget-mini-installments.js', [], PAYU_PLUGIN_VERSION );
+	wp_enqueue_script( 'payu-installments-widget', 'https://static.payu.com/res/v2/widget-mini-installments.js' );
 
 	?>
     <div>
@@ -474,7 +474,7 @@ function installments_mini_total() {
     $lang = get_site_language();
     $currency = get_woocommerce_currency();
 
-	wp_enqueue_script( 'payu-installments-widget', 'https://static.payu.com/res/v2/widget-mini-installments.js', [], PAYU_PLUGIN_VERSION );
+	wp_enqueue_script( 'payu-installments-widget', 'https://static.payu.com/res/v2/widget-mini-installments.js' );
 
 	?>
     <tr>
@@ -535,7 +535,7 @@ function installments_mini_aware_product_block( $html, $data, $product ) {
     $lang = get_site_language();
     $currency = get_woocommerce_currency();
 
-	wp_enqueue_script( 'payu-installments-widget', 'https://static.payu.com/res/v2/widget-mini-installments.js', [], PAYU_PLUGIN_VERSION );
+	wp_enqueue_script( 'payu-installments-widget', 'https://static.payu.com/res/v2/widget-mini-installments.js' );
 
 	return "<li class=\"wc-block-grid__product\">
         <div >


### PR DESCRIPTION
Changes:
- limited credit widget script to be loaded, only when it is going to be displayed on given page.
- removed unnecessary versioning of credit widget script based on plugin version.
- fixed error in readme.